### PR TITLE
Add «changesNotSentForReview» option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Options:
   -p, --packageName <name>  set package name (com.some.app)
   -a, --aabFile <path>      set path to .aab file
   -t, --track <track>       set track (production, beta, alpha...)
+  -c, --changesNotSentForReview true   set changesNotSentForReview flag
   -e, --exit                exit on error with error code 1.
   -h, --help                output usage information
 ```
@@ -22,7 +23,7 @@ Options:
 *Example:* 
 
 ```bash
-$ publish-aab-google-play -k ./api-publish.json -p com.laCosaNostra.FiveHundredAndTwelve2 -a ./platforms/android/app/build/outputs/bundle/release/app.aab -t beta
+$ publish-aab-google-play -k ./api-publish.json -p com.laCosaNostra.FiveHundredAndTwelve2 -a ./platforms/android/app/build/outputs/bundle/release/app.aab -t beta -c true
 ```
 
 **Use in your own program**

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -14,6 +14,7 @@ program
     "-t, --track <track>",
     "set track (production, beta, alpha...)"
   )
+  .option("-c, --changesNotSentForReview", "Set changesNotSentForReview flag")
   .option("-e, --exit", "exit on error with error code 1.")
   .parse(process.argv);
 
@@ -24,6 +25,7 @@ publish({
   packageName: options.packageName,
   aabFile: join(process.cwd(), options.aabFile),
   track: options.track,
+  changesNotSentForReview: options.changesNotSentForReview,
 })
   .then(() => {
     console.log("Publish complete.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,11 +73,13 @@ const setTrack = (
 const commit = (
   androidPublisher: ReturnType<typeof getAndroidPublisher>,
   editId: string,
-  packageName: string
+  packageName: string,
+  changesNotSentForReview: boolean
 ) =>
   androidPublisher.edits.commit({
     editId,
-    packageName
+    packageName,
+    changesNotSentForReview
   });
 
 const getAABStream = (filePath: string) => createReadStream(filePath);
@@ -88,13 +90,15 @@ interface SchemaPublish {
   packageName: string;
   aabFile: string;
   track: string;
+  changesNotSentForReview: boolean
 }
 
 export const publish = async ({
   keyFile,
   packageName,
   aabFile,
-  track
+  track,
+  changesNotSentForReview = false,
 }: SchemaPublish) => {
   const client = await getClient(keyFile);
   const stream = getAABStream(aabFile);
@@ -102,7 +106,9 @@ export const publish = async ({
   const id = getId();
   const edit = await startEdit(androidPublisher, id);
   const editId = String(edit.data.id);
+  console.log("Start package upload...")
   const bundle = await upload(androidPublisher, editId, packageName, stream);
+  console.log("Package uploaded")
   if (
     bundle.data.versionCode === undefined ||
     bundle.data.versionCode === null
@@ -116,6 +122,6 @@ export const publish = async ({
     track,
     String(bundle.data.versionCode)
   );
-  await commit(androidPublisher, editId, packageName);
+  await commit(androidPublisher, editId, packageName, changesNotSentForReview);
 };
 


### PR DESCRIPTION
I use your package for months but recently I get this error

`Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.`

My changes are backward compatible (the new option is default to false)