### PR TITLE
Adding property to change the status when uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Options:
   -a, --aabFile <path>      set path to .aab file
   -t, --track <track>       set track (production, beta, alpha...)
   -c, --changesNotSentForReview true   set changesNotSentForReview flag
+  -s  --status              set status at the store i.e draft, completed
   -e, --exit                exit on error with error code 1.
   -h, --help                output usage information
 ```

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -15,6 +15,7 @@ program
     "set track (production, beta, alpha...)"
   )
   .option("-c, --changesNotSentForReview", "Set changesNotSentForReview flag")
+  .option("-s, --status", "Set the status at the store")
   .option("-e, --exit", "exit on error with error code 1.")
   .parse(process.argv);
 
@@ -26,6 +27,7 @@ publish({
   aabFile: join(process.cwd(), options.aabFile),
   track: options.track,
   changesNotSentForReview: options.changesNotSentForReview,
+  status: options.status || 'completed'
 })
   .then(() => {
     console.log("Publish complete.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,8 @@ const setTrack = (
   editId: string,
   packageName: string,
   track: string,
-  versionCode: string
+  versionCode: string,
+  status: string = "completed"
 ) =>
   androidPublisher.edits.tracks.update({
     editId,
@@ -63,7 +64,7 @@ const setTrack = (
       track: track,
       releases: [
         {
-          status: "completed",
+          status: status,
           versionCodes: [versionCode]
         }
       ]
@@ -74,7 +75,7 @@ const commit = (
   androidPublisher: ReturnType<typeof getAndroidPublisher>,
   editId: string,
   packageName: string,
-  changesNotSentForReview: boolean
+  changesNotSentForReview: boolean,
 ) =>
   androidPublisher.edits.commit({
     editId,
@@ -91,6 +92,7 @@ interface SchemaPublish {
   aabFile: string;
   track: string;
   changesNotSentForReview: boolean
+  status?: string
 }
 
 export const publish = async ({
@@ -99,6 +101,7 @@ export const publish = async ({
   aabFile,
   track,
   changesNotSentForReview = false,
+  status
 }: SchemaPublish) => {
   const client = await getClient(keyFile);
   const stream = getAABStream(aabFile);
@@ -118,7 +121,8 @@ export const publish = async ({
     editId,
     packageName,
     track,
-    String(bundle.data.versionCode)
+    String(bundle.data.versionCode),
+    status
   );
   await commit(androidPublisher, editId, packageName, changesNotSentForReview);
 };


### PR DESCRIPTION
Some store publishing process goes parallel from development process.
In which we need a way to upload  aab to internal even store status is draft. 
When publishing with the status "completed" will throw error uploading. 

`  errors: [
    {
      message: 'Only releases with status draft may be created on draft app.',
      domain: 'global',
      reason: 'badRequest'
    }
  ]
`

This change is to enable uploadig aab with the status 'draft' 